### PR TITLE
Suggesting to add a setup.py for proper installation and distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,13 @@
+"""
+At the moment, this would allow the installation of P3 but submodules are installed individually, 
+i.e. instead of "import P3 / from P3 install aoSystem", 
+
+You need to do import the relevant submodules:
+    e.g. import psfao21/aoSystem ... 
+"""
+
 from setuptools import setup, find_packages
 
 setup(name='P3',
-      version='0.0.0beta',
       url='https://github.com/oliviermartin-lam/P3.git',
       packages=find_packages())


### PR DESCRIPTION
Hello, 

I just noticed that there isn't a setup.py file. 

At the moment, this would allow the installation of P3 but submodules are installed individually, 
i.e. instead of "`import P3 / from P3 install aoSystem`", You need to do import the relevant submodules:    
e.g. `import psfao21/aoSystem` ... 

This can be changed if you create a higher level directory and put setup.py in there. 
If you want, you can add version, description, emails e.t.c. (https://docs.python.org/3/distutils/setupscript.html)
