### PR TITLE
Update FourierUtils.py, invoking argmax as a np/cp module member inst…

### DIFF
--- a/p3/aoSystem/FourierUtils.py
+++ b/p3/aoSystem/FourierUtils.py
@@ -1023,7 +1023,7 @@ def getFWHM(psf,pixelScale,rebin=1,method='contour',nargout=2,center=None,std_gu
     
     if method == 'cutting':
         # X and Y profiles passing through the max
-        y_max, x_max = nnp.unravel_index(np.argmax(im_hr), im_hr.shape)
+        y_max, x_max = nnp.unravel_index(im_hr.argmax(), im_hr.shape)
         profile_x = im_hr[y_max, :]
         profile_y = im_hr[:, x_max]
 


### PR DESCRIPTION
…ead of as an array object member causing error in some version of cupy.