### PR TITLE
(GA) Introduce minPixLoD to control PSD oversampling

### DIFF
--- a/p3/aoSystem/aoSystem.py
+++ b/p3/aoSystem/aoSystem.py
@@ -61,6 +61,21 @@ class aoSystem():
         except Exception:
             return value
 
+    def _resolve_min_pix_lod(self):
+        """Resolve the minimum internal sampling policy in pixels per lambda/D."""
+        if self.check_section_key('COMPUTATION'):
+            if self.check_config_key('COMPUTATION', 'minPixLoD'):
+                value = self.get_config_value('COMPUTATION', 'minPixLoD')
+            else:
+                value = 2.0
+        else:
+            value = 2.0
+
+        value = float(np.asarray(value).reshape(-1)[0])
+        if not np.isfinite(value) or value <= 0:
+            raise ValueError("minPixLoD must be a positive finite number")
+        return value
+
     def _compute_science_field_of_view(self, science_wavelength, pixel_scale, dm_pitchs):
         rad2mas = 180 * 3600 * 1e3 / np.pi
         wvl_min = float(np.min(np.atleast_1d(science_wavelength)))
@@ -164,6 +179,9 @@ class aoSystem():
         elif self.precision == 'double':
             self.dtype = np.float64
             self.complex_dtype = np.complex128
+
+        # Internal sampling policy used by frequencyDomain.
+        self.minPixLoD = self._resolve_min_pix_lod()
 
         self.getPSDatNGSpositions = getPSDatNGSpositions
 

--- a/p3/aoSystem/frequencyDomain.py
+++ b/p3/aoSystem/frequencyDomain.py
@@ -20,6 +20,18 @@ rad2arc = rad2mas / 1000
 
 class frequencyDomain():
 
+    def _resolve_min_pix_lod(self):
+        """Resolve sampling policy from aoSystem configuration."""
+        if hasattr(self.ao, 'minPixLoD'):
+            value = self.ao.minPixLoD
+        else:
+            value = 2.0
+
+        value = float(np.asarray(value).reshape(-1)[0])
+        if not np.isfinite(value) or value <= 0:
+            raise ValueError("minPixLoD must be a positive finite number")
+        return np.asarray(value, dtype=self.dtype)
+
     # CUT-OFF FREQUENCY
     @property
     def pitch(self):
@@ -103,6 +115,7 @@ class frequencyDomain():
             self.kcExt = None
 
         self.Hfilter = Hfilter
+        self.minPixLoD = self._resolve_min_pix_lod()
 
         # MANAGING THE WAVELENGTH
         self.nBin = self.ao.cam.nWvl # number of spectral bins for polychromatic PSFs
@@ -132,27 +145,36 @@ class frequencyDomain():
         self.wvlRef = self.wvl_[idxWmin]
 
         if self.nyquistSampling == True:
-            self.psInMas    = rad2mas*self.wvl/self.ao.tel.D/2
-            self.psInMasCen = rad2mas*wvlCen_/self.ao.tel.D/2
-            samp  = 2.0 * np.ones_like(self.psInMas)
+            self.psInMasRequested = rad2mas*self.wvl/self.ao.tel.D/2
+            self.psInMasCenRequested = rad2mas*wvlCen_/self.ao.tel.D/2
+            samp  = 2.0 * np.ones_like(self.psInMasRequested)
             sampCen  = 2.0 * np.ones(len(self.wvlCen), dtype=self.dtype)
             sampRef  = 2.0 * np.ones(len(self.wvlCen), dtype=self.dtype)
 
         else:
-            self.psInMas    = self.ao.cam.psInMas * np.ones(self.nWvl, dtype=self.dtype)
-            self.psInMasCen = self.ao.cam.psInMas * np.ones(self.nWvlCen, dtype=self.dtype)
-            samp  = self.wvl* rad2mas / (self.psInMas*self.ao.tel.D)
-            sampCen  = self.wvlCen * rad2mas / (self.psInMasCen*self.ao.tel.D)
+            self.psInMasRequested = self.ao.cam.psInMas * np.ones(self.nWvl, dtype=self.dtype)
+            self.psInMasCenRequested = self.ao.cam.psInMas * np.ones(self.nWvlCen, dtype=self.dtype)
+            samp  = self.wvl* rad2mas / (self.psInMasRequested*self.ao.tel.D)
+            sampCen  = self.wvlCen * rad2mas / (self.psInMasCenRequested*self.ao.tel.D)
             sampRef  = np.asarray(self.wvlRef * rad2mas, dtype=self.dtype) \
-                       / np.asarray(self.psInMas[0]*self.ao.tel.D, dtype=self.dtype)
+                       / np.asarray(self.psInMasRequested[0]*self.ao.tel.D, dtype=self.dtype)
 
-        self.k_      = np.ceil(2.0/samp).astype('int') # works for oversampling
+        # Backward compatible aliases used across P3/TIPTOP call sites.
+        self.psInMas = self.psInMasRequested
+        self.psInMasCen = self.psInMasCenRequested
+
+        self.k_      = np.ceil(self.minPixLoD/samp).astype('int')
+        self.k_      = np.maximum(self.k_, 1)
         self.samp    = self.k_ * samp
 
-        self.kCen_   = np.ceil(2.0/sampCen).astype('int') # works for oversampling
+        self.kCen_   = np.ceil(self.minPixLoD/sampCen).astype('int')
+        self.kCen_   = np.maximum(self.kCen_, 1)
         self.sampCen = self.kCen_ * sampCen
 
-        psdSteps = self.psInMas/(self.wvl*rad2mas*self.k_)
+        self.psInMasInternal = self.psInMasRequested / self.k_
+        self.psInMasCenInternal = self.psInMasCenRequested / self.kCen_
+
+        psdSteps = self.psInMasRequested/(self.wvl*rad2mas*self.k_)
         if psdSteps.shape[0] > 1:
             idxPmin = nnp.argmin(psdSteps)
         else:
@@ -163,6 +185,8 @@ class frequencyDomain():
             self.kRef_   = int(self.k_[idxPmin]) # works for oversampling
         else:
             self.kRef_   = int(self.k_[idxWmin]) # works for oversampling
+        self.oversamplingFactor = int(self.kRef_)
+        self.oversamplingFactorPerWavelength = np.asarray(self.k_, dtype='int')
         self.sampRef = self.kRef_ * sampRef
 
         self.nOtf    = self.nPix * self.kRef_
@@ -209,6 +233,7 @@ class frequencyDomain():
 
         s = '__ FREQUENCY DOMAIN __\n' + '--------------------------------------------- \n'
         s += '. Reference wavelength : %.2f µm\n'%(self.wvlRef*1e6)
+        s += '. min pixels per lambda/D : %.2f\n'%(float(self.minPixLoD))
         s += '. Oversampling factor at the reference wavelength : %.2f\n'%(self.sampRef)
         s += '. Size of the frequency domain : %d pixels\n'%(self.nOtf)
         s += '. Pixel scale at the reference wavelength : %.4f m^-1\n'%(self.PSDstep)

--- a/tests/test_fourier_model_validation.py
+++ b/tests/test_fourier_model_validation.py
@@ -83,3 +83,24 @@ class TestFourierModelValidation(unittest.TestCase):
         self.assertIn("nOtf=32", msg)
         self.assertIn("resAO=32", msg)
         self.assertIn("fovInPix=8", msg)
+
+    def test_fourier_model_does_not_forward_min_pixels_policy_argument(self):
+        ao = self._base_ao(fov_in_pix=8)
+
+        with patch(
+            "p3.aoSystem.fourierModel.FourierUtils.create_wavelength_vector",
+            return_value=(np.array([1.65e-6]), 1),
+        ), patch(
+            "p3.aoSystem.fourierModel.frequencyDomain",
+            side_effect=RuntimeError("sentinel-frequency-domain-call"),
+        ) as freq_ctor:
+            with self.assertRaisesRegex(RuntimeError, "sentinel-frequency-domain-call"):
+                fourierModel(
+                    path_ini="unused.ini",
+                    ao=ao,
+                    doComputations=True,
+                    calcPSF=False,
+                )
+
+        self.assertTrue(freq_ctor.called)
+        self.assertNotIn("minPixLoD", freq_ctor.call_args.kwargs)

--- a/tests/test_p3_all.py
+++ b/tests/test_p3_all.py
@@ -318,6 +318,56 @@ class TestAOSystemExtracted(unittest.TestCase):
                 self.assertIsNotNone(ao)
                 self.assertIsNotNone(freq)
 
+    def test_frequency_domain_min_pixels_policy_from_config(self):
+        """frequencyDomain reads minPixLoD from [COMPUTATION]."""
+        template_ini = os.path.join(self.path_ao, 'parFiles', 'nirc2.ini')
+        config = ConfigParser()
+        config.optionxform = str
+        config.read(template_ini)
+        config.set('sensor_science', 'PixelScale', '30.0')
+        if not config.has_section('COMPUTATION'):
+            config.add_section('COMPUTATION')
+        config.set('COMPUTATION', 'minPixLoD', '1.0')
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as temp_file:
+            config.write(temp_file)
+            temp_name = temp_file.name
+
+        try:
+            ao = aoSystem(temp_name, path_root=self.path_p3, verbose=False)
+            freq = frequencyDomain(ao)
+            self.assertAlmostEqual(float(freq.minPixLoD), 1.0)
+
+            rad2mas_local = 3600 * 180 * 1000 / np.pi
+            samp = freq.wvl * rad2mas_local / (freq.psInMas * ao.tel.D)
+            expected_k = np.maximum(1, np.ceil(1.0 / samp).astype(int))
+            np.testing.assert_array_equal(freq.k_, expected_k)
+            np.testing.assert_allclose(freq.psInMasInternal, freq.psInMas / expected_k)
+        finally:
+            if os.path.exists(temp_name):
+                os.remove(temp_name)
+
+    def test_frequency_domain_min_pixels_policy_rejects_invalid_values(self):
+        """frequencyDomain rejects non-positive minPixLoD values."""
+        template_ini = os.path.join(self.path_ao, 'parFiles', 'nirc2.ini')
+        config = ConfigParser()
+        config.optionxform = str
+        config.read(template_ini)
+        if not config.has_section('COMPUTATION'):
+            config.add_section('COMPUTATION')
+        config.set('COMPUTATION', 'minPixLoD', '-1.0')
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as temp_file:
+            config.write(temp_file)
+            temp_name = temp_file.name
+
+        try:
+            with self.assertRaisesRegex(ValueError, 'minPixLoD'):
+                aoSystem(temp_name, path_root=self.path_p3, verbose=False)
+        finally:
+            if os.path.exists(temp_name):
+                os.remove(temp_name)
+
     def test_fourier_psd_selected_systems(self):
         """Run Fourier PSD model (no PSF) for selected configs."""
         for sys_name in ['nirc2', 'irdis', 'eris']:


### PR DESCRIPTION
This PR introduces a config-driven `minPixLoD` parameter to control the internal PSD oversampling strategy. It keeps the external science pixel scale unchanged while ensuring the internal Fourier sampling remains robust and the final PSF is rebinned consistently.